### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
 jobs:
 
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/MitulShah1/golang-rest-api-template/security/code-scanning/3](https://github.com/MitulShah1/golang-rest-api-template/security/code-scanning/3)

To fix the problem, you should add a `permissions` block to the workflow file, specifying the least privilege required. For this workflow, the minimal required permission is `contents: read`, which allows the workflow to read repository contents but not write to them. This block should be added at the root level of the workflow file (above `jobs:`), so it applies to all jobs unless overridden. No additional imports or definitions are needed; this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
